### PR TITLE
GM-114 동네ID로 주소 조회 기능

### DIFF
--- a/src/main/java/com/gaaji/town/applicationservice/TownRetrieveService.java
+++ b/src/main/java/com/gaaji/town/applicationservice/TownRetrieveService.java
@@ -1,9 +1,12 @@
 package com.gaaji.town.applicationservice;
 
+import com.gaaji.town.controller.dto.TownAddressResponse;
 import com.gaaji.town.controller.dto.TownRetrieveResponse;
 import java.util.List;
 
 public interface TownRetrieveService {
 
     List<TownRetrieveResponse> retrieveMyTown(String authId);
+
+    TownAddressResponse retrieveTownAddress(String townId);
 }

--- a/src/main/java/com/gaaji/town/applicationservice/impl/TownRetrieveServiceImpl.java
+++ b/src/main/java/com/gaaji/town/applicationservice/impl/TownRetrieveServiceImpl.java
@@ -1,6 +1,7 @@
 package com.gaaji.town.applicationservice.impl;
 
 import com.gaaji.town.applicationservice.TownRetrieveService;
+import com.gaaji.town.controller.dto.TownAddressResponse;
 import com.gaaji.town.controller.dto.TownRetrieveResponse;
 import com.gaaji.town.domain.AuthId;
 import com.gaaji.town.domain.TownId;
@@ -29,5 +30,10 @@ public class TownRetrieveServiceImpl implements
         }
 
         return townRetrieveResponse;
+    }
+
+    @Override
+    public TownAddressResponse retrieveTownAddress(String townId) {
+        return TownAddressResponse.of(townRepository.findByTownId(TownId.of(townId)).getAddress2());
     }
 }

--- a/src/main/java/com/gaaji/town/controller/TownRetrieveController.java
+++ b/src/main/java/com/gaaji/town/controller/TownRetrieveController.java
@@ -1,11 +1,13 @@
 package com.gaaji.town.controller;
 
 import com.gaaji.town.applicationservice.TownRetrieveService;
+import com.gaaji.town.controller.dto.TownAddressResponse;
 import com.gaaji.town.controller.dto.TownRetrieveResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +25,11 @@ public class TownRetrieveController {
             @RequestHeader("authId") String authId){
         List<TownRetrieveResponse> towns = townRetrieveService.retrieveMyTown(authId);
         return ResponseEntity.ok(towns);
+    }
+
+    @GetMapping("/{townId}")
+    public ResponseEntity<TownAddressResponse> retrieveTownAddress(@PathVariable("townId") String townId){
+        TownAddressResponse dto = townRetrieveService.retrieveTownAddress(townId);
+        return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/com/gaaji/town/controller/dto/TownAddressResponse.java
+++ b/src/main/java/com/gaaji/town/controller/dto/TownAddressResponse.java
@@ -1,0 +1,18 @@
+package com.gaaji.town.controller.dto;
+
+
+import javax.persistence.Access;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE) @NoArgsConstructor
+public class TownAddressResponse {
+    private String address;
+
+    public static TownAddressResponse of(String address){
+        return new TownAddressResponse(address);
+    }
+}


### PR DESCRIPTION

### 개요
중고 거래 글 작성에 필요한 동네 주소를 위해 동네 ID를 받아서 주소를 반환하는 기능을 추가했다.

#### 시나리오
동네 ID로 동네 주소 반환하기.(동기통신)
중고거래로 부터 동네 ID를 전달받음.
1. B : 동네 ID 로 동네 주소2(읍/면/동)을 반환하기.

#### API
[GET] /town/:townId
response : address (address2(string) )

코드는 기존 조회 기능을 수행하던 TownRetriveService 하위에 추가했음.
