### PR TITLE
GM-182 회원ID 헤더 변경

### DIFF
--- a/src/main/java/com/gaaji/town/TownApplication.java
+++ b/src/main/java/com/gaaji/town/TownApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 
-//@EnableEurekaClient
+@EnableEurekaClient
 @SpringBootApplication
 public class TownApplication {
 

--- a/src/main/java/com/gaaji/town/controller/TownAuthenticationController.java
+++ b/src/main/java/com/gaaji/town/controller/TownAuthenticationController.java
@@ -3,6 +3,7 @@ package com.gaaji.town.controller;
 import com.gaaji.town.applicationservice.TownAuthenticationService;
 import com.gaaji.town.controller.dto.CheckAuthenticateResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,7 +21,7 @@ public class TownAuthenticationController {
 
     @PatchMapping("/authentication/{townId}")
     public ResponseEntity<Void> authenticateTown(@PathVariable("townId") String townId ,
-            @RequestHeader("authId") String authId){
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId){
             townAuthenticationService.authenticateTown(townId, authId);
             return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gaaji/town/controller/TownEditController.java
+++ b/src/main/java/com/gaaji/town/controller/TownEditController.java
@@ -3,6 +3,7 @@ package com.gaaji.town.controller;
 import com.gaaji.town.applicationservice.TownEditService;
 import com.gaaji.town.controller.dto.TownEditRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +21,7 @@ public class TownEditController {
 
     @PatchMapping
     public ResponseEntity<Void> editTown(@RequestBody TownEditRequest dto,
-            @RequestHeader("authId") String authId){
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId){
         townEditService.editTown(authId, dto.getOriginalTownId(), dto.getAddress1(), dto.getAddress2());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/gaaji/town/controller/TownRegisterController.java
+++ b/src/main/java/com/gaaji/town/controller/TownRegisterController.java
@@ -3,6 +3,7 @@ package com.gaaji.town.controller;
 import com.gaaji.town.applicationservice.TownRegisterService;
 import com.gaaji.town.controller.dto.TownRegisterRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +20,7 @@ public class TownRegisterController {
     private final TownRegisterService townRegisterService;
 
     @PostMapping
-    public ResponseEntity<Void> registerTown(@RequestHeader String authId, @RequestBody TownRegisterRequest dto){
+    public ResponseEntity<Void> registerTown(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody TownRegisterRequest dto){
         townRegisterService.registerTown(authId,dto.getAddress1(),dto.getAddress2());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/gaaji/town/controller/TownRetrieveController.java
+++ b/src/main/java/com/gaaji/town/controller/TownRetrieveController.java
@@ -5,6 +5,7 @@ import com.gaaji.town.controller.dto.TownAddressResponse;
 import com.gaaji.town.controller.dto.TownRetrieveResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,7 +23,7 @@ public class TownRetrieveController {
 
     @GetMapping
     public ResponseEntity<List<TownRetrieveResponse>> retrieveMyTown(
-            @RequestHeader("authId") String authId){
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId){
         List<TownRetrieveResponse> towns = townRetrieveService.retrieveMyTown(authId);
         return ResponseEntity.ok(towns);
     }

--- a/src/main/java/com/gaaji/town/controller/TownTownCreateController.java
+++ b/src/main/java/com/gaaji/town/controller/TownTownCreateController.java
@@ -2,6 +2,7 @@ package com.gaaji.town.controller;
 
 import com.gaaji.town.applicationservice.TownTokenCreateService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +18,7 @@ public class TownTownCreateController {
     private final TownTokenCreateService townTokenCreateService;
 
     @PostMapping("/token")
-    public ResponseEntity<Void> checkAuthentication(@RequestHeader("authId") String authId){
+    public ResponseEntity<Void> checkAuthentication( @RequestHeader(HttpHeaders.AUTHORIZATION) String authId){
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header("X-TOWN-TOKEN", townTokenCreateService
                         .createAuthenticationToken(authId)).build();


### PR DESCRIPTION
# GM-182 회원ID 헤더 변경
## Description
> 컨트롤러에서 회원 ID를 전달 받는 헤더 명칭을 변경한다.

## PR Type
- [ ] Hotfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [X] Other... Please describe : 내용 변경

## Related Issues
-  X

## Issues
header의 이름을 authId -> AUTHORIZATION으로 변경하였다.

## Conclusion  
> 이미 이전에 설정은 해 놓았지만 따로 푸쉬를 안해서 늦게 작업이 이루어졌다.
